### PR TITLE
SCRUM-70 Fix Documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,10 +7,12 @@ Access the hosted version of the application here: https://cyborg-network.github
 ### Installation
 
 ```bash
-# Clone the repository
-git https://github.com/Cyborg-Network/cyborg-connect.git
-cd cyborg-connect
-npm install
+    # Clone the repository
+    git clone https://github.com/Cyborg-Network/cyborg-connect.git
+
+    cd cyborg-connect
+
+    npm install
 ```
 
 ### Usage
@@ -18,13 +20,13 @@ npm install
 You can start in development mode to connect to a locally running node
 
 ```bash
-npm run start
+    npm run start
 ```
 
 You can also build the app in production mode,
 
 ```bash
-npm run build
+    npm run build
 ```
 
 and open `build/index.html` in your favorite browser.


### PR DESCRIPTION
1. Fix typo-error on the installation instruction:
    -   add `git clone https://github.com/Cyborg-Network/cyborg-connect.git`