### PR TITLE
feat: Implement model encryption using Diffie-Hellman key exchange

### DIFF
--- a/src/cyborg/components/accessCompute/modals/NeuroZKUpload.tsx
+++ b/src/cyborg/components/accessCompute/modals/NeuroZKUpload.tsx
@@ -67,17 +67,17 @@ const NeuroZkUpload: React.FC<Props> = ({
 
   const uploadModel = async () => {
     if (!zkFiles.model || !zkFiles.publicInput) {
-      toast('Please upload both model and public input files!')
-      return
+      toast('Please upload both model and public input files!');
+      return;
     }
 
-    const formData = new FormData()
-
-    formData.append('model.onnx', zkFiles.model)
-    formData.append('publicInput.json', zkFiles.publicInput)
+    const formData = new FormData();
+    formData.append('model.onnx', zkFiles.model);
+    formData.append('publicInput.json', zkFiles.publicInput);
 
     uploadFile(formData, minerAdress, minerId);
-  }
+  };
+
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const { files } = e.target

--- a/src/cyborg/util/non-bc-crypto/modelEncryotion.ts
+++ b/src/cyborg/util/non-bc-crypto/modelEncryotion.ts
@@ -1,0 +1,42 @@
+import sodium from 'libsodium-wrappers';
+import { X25519KeyPair } from './generateX25519KeyPair';
+
+export const deriveSharedSecret = async (
+  privateKey: Uint8Array,
+  minerPublicKey: Uint8Array
+): Promise<Uint8Array> => {
+  await sodium.ready;
+  return sodium.crypto_scalarmult(privateKey, minerPublicKey);
+};
+
+export const encryptModel = async (
+  file: File,
+  sharedSecret: Uint8Array
+): Promise<{ encryptedFile: Blob; nonce: Uint8Array }> => {
+  await sodium.ready;
+  
+  // Read file as ArrayBuffer
+  const fileBuffer = await file.arrayBuffer();
+  const fileBytes = new Uint8Array(fileBuffer);
+  
+  // Generate random nonce
+  const nonce = sodium.randombytes_buf(sodium.crypto_secretbox_NONCEBYTES);
+  
+  // Encrypt the file
+  const encryptedBytes = sodium.crypto_secretbox_easy(
+    fileBytes,
+    nonce,
+    sharedSecret
+  );
+  
+  return {
+    encryptedFile: new Blob([encryptedBytes], { type: file.type }),
+    nonce
+  };
+};
+
+export const accountIdToPublicKey = (accountId: string): Uint8Array => {
+  // Remove the SS58 prefix (first byte) to get the raw public key
+  const decoded = sodium.from_hex(accountId.slice(2)); // Remove '0x' prefix
+  return decoded.slice(0, 32); // Take first 32 bytes (public key)
+};


### PR DESCRIPTION
Currently, models stored on CESS nodes are unencrypted, exposing them to potential security risks during transit and storage.

This PR implements end-to-end encryption for models before they are uploaded to CESS storage using a Diffie-Hellman key exchange between the frontend (cyborg-connect) and the miner.